### PR TITLE
Issue 11 - layout/design_layout_snackbar_include: Error inflating class android.widget.Button

### DIFF
--- a/sample/Maui.Android.InAppUpdates.SampleApp.csproj
+++ b/sample/Maui.Android.InAppUpdates.SampleApp.csproj
@@ -63,7 +63,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
+		<PackageReference Include="Microsoft.Maui.Controls" Version="9.0.82" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="9.0.5" />
 		<PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
 	</ItemGroup>

--- a/sample/Maui.Android.InAppUpdates.SampleApp.csproj
+++ b/sample/Maui.Android.InAppUpdates.SampleApp.csproj
@@ -64,7 +64,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.Maui.Controls" Version="9.0.82" />
-		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="9.0.5" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="9.0.7" />
 		<PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
 	</ItemGroup>
 

--- a/sample/Maui.Android.InAppUpdates.SampleApp.csproj
+++ b/sample/Maui.Android.InAppUpdates.SampleApp.csproj
@@ -63,7 +63,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Maui.Controls" Version="9.0.82" />
+		<PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="9.0.7" />
 		<PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
 	</ItemGroup>

--- a/src/libs/Maui.Android.InAppUpdates/Maui.Android.InAppUpdates.csproj
+++ b/src/libs/Maui.Android.InAppUpdates/Maui.Android.InAppUpdates.csproj
@@ -31,10 +31,10 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net9.0-android'" Label="Android In-app Updates">
-    <PackageReference Include="Xamarin.AndroidX.Activity.Ktx" Version="1.10.1.1" />
-    <PackageReference Include="Xamarin.AndroidX.Collection.Ktx" Version="1.5.0.1" />
-    <PackageReference Include="Xamarin.AndroidX.Fragment.Ktx" Version="1.8.6.1" />
-    <PackageReference Include="Xamarin.Google.Android.Play.App.Update.Ktx" Version="2.1.0.14" />
+    <PackageReference Include="Xamarin.AndroidX.Activity.Ktx" Version="1.10.1.2" />
+    <PackageReference Include="Xamarin.AndroidX.Collection.Ktx" Version="1.5.0.2" />
+    <PackageReference Include="Xamarin.AndroidX.Fragment.Ktx" Version="1.8.8" />
+    <PackageReference Include="Xamarin.Google.Android.Play.App.Update.Ktx" Version="2.1.0.15" />
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetFramework.StartsWith('Xamarin.iOS')) != true AND $(TargetFramework.StartsWith('net9.0-ios')) != true AND $(TargetFramework.StartsWith('net9.0-maccatalyst')) != true ">

--- a/src/libs/Maui.Android.InAppUpdates/Maui.Android.InAppUpdates.csproj
+++ b/src/libs/Maui.Android.InAppUpdates/Maui.Android.InAppUpdates.csproj
@@ -27,7 +27,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
+    <PackageReference Include="Microsoft.Maui.Controls" Version="9.0.82" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net9.0-android'" Label="Android In-app Updates">

--- a/src/libs/Maui.Android.InAppUpdates/Maui.Android.InAppUpdates.csproj
+++ b/src/libs/Maui.Android.InAppUpdates/Maui.Android.InAppUpdates.csproj
@@ -19,7 +19,7 @@
     <TargetPlatformMinVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</TargetPlatformMinVersion>
     <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'tizen'">6.5</SupportedOSPlatformVersion>
   </PropertyGroup>
-  
+
   <PropertyGroup Label="NuGet">
     <PackageId>Oscore.$(AssemblyName)</PackageId>
     <Description>NuGet package that implementing Android In-App Updates for MAUI with debugging capabilities.</Description>
@@ -27,7 +27,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Maui.Controls" Version="9.0.82" />
+	  <PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net9.0-android'" Label="Android In-app Updates">

--- a/src/libs/Maui.Android.InAppUpdates/Platforms/Android/DefaultUserInterface.cs
+++ b/src/libs/Maui.Android.InAppUpdates/Platforms/Android/DefaultUserInterface.cs
@@ -10,38 +10,119 @@ public static class DefaultUserInterface
     /// Displays a short duration toast message at the center of the screen.
     /// </summary>
     /// <param name="text">The text to be displayed in the toast message.</param>
-    public static void ShowShortToast(
-        string text)
+    public static void ShowShortToast(string text)
     {
-        Toast.MakeText(
-            context: Platform.AppContext,
-            text: text,
-            duration: ToastLength.Short)?.Show();
+        try
+        {
+            if (Platform.AppContext is null)
+            {
+                Handler.Options.DebugAction($"Cannot show toast - Platform.AppContext is null: {text}");
+                return;
+            }
+
+            Toast.MakeText(
+                context: Platform.AppContext,
+                text: text,
+                duration: ToastLength.Short)?.Show();
+        }
+        catch (Exception ex)
+        {
+            Handler.Options.DebugAction($"Failed to show toast '{text}': {ex}");
+        }
     }
 
     /// <summary>
     /// Displays a snackbar with an action to complete the app update process.
+    /// If snackbar fails due to theme incompatibility, falls back to toast message.
     /// </summary>
     /// <param name="text">The text to display on the snackbar.</param>
     /// <param name="actionText">The text for the action button.</param>
-    /// <param name="clickHandler">The handler for the action button.</param>
+    /// <param name="clickHandler">The handler for the action button. Can be null if no action is needed.</param>
     public static void ShowSnackbar(
         string text,
         string actionText,
         Action<global::Android.Views.View> clickHandler)
     {
-        if (Platform.CurrentActivity?.Window?.DecorView is not {} view ||
-            Snackbar.Make(
-                text: text,
-                duration: BaseTransientBottomBar.LengthIndefinite,
-                view: view) is not {} snackbar)
+        var fallbackMessage = $"{text} - {actionText}";
+
+        try
         {
-            return;
+            var view = Platform.CurrentActivity?.Window?.DecorView;
+            if (view is null)
+            {
+                FallbackToToastWithAction("Cannot show snackbar - no active view", fallbackMessage, clickHandler, null);
+                return;
+            }
+
+            var snackbar = Snackbar.Make(view, text, BaseTransientBottomBar.LengthIndefinite);
+            if (snackbar is null)
+            {
+                FallbackToToastWithAction("Cannot create snackbar", fallbackMessage, clickHandler, view);
+                return;
+            }
+
+            snackbar.SetAction(text: actionText, clickHandler: clickHandler);
+            snackbar.Show();
         }
-        
-        snackbar.SetAction(
-            text: actionText,
-            clickHandler: clickHandler);
-        snackbar.Show();
+        catch (Exception ex) when (IsThemeRelated(ex))
+        {
+            HandleSnackbarFailure(ex, "theme related", fallbackMessage, clickHandler, Platform.CurrentActivity?.Window?.DecorView);
+        }
+        catch (Exception ex)
+        {
+            HandleSnackbarFailure(ex, "general exception", fallbackMessage, null, null);
+        }
     }
+
+    private static void FallbackToToastWithAction(
+        string debugMessage,
+        string fallbackMessage,
+        Action<global::Android.Views.View>? clickHandler,
+        global::Android.Views.View? fallbackView)
+    {
+        Handler.Options.DebugAction($"{debugMessage}, falling back to toast and auto-triggering action");
+        ShowShortToast(fallbackMessage);
+
+        // Auto-trigger the action since user can't click the snackbar
+        if (clickHandler is not null && fallbackView is not null)
+        {
+            try
+            {
+                clickHandler(fallbackView);
+            }
+            catch (Exception actionEx)
+            {
+                Handler.Options.DebugAction($"Error auto-executing snackbar action: {actionEx}");
+            }
+        }
+    }
+
+    private static void HandleSnackbarFailure(
+        Exception ex,
+        string errorType,
+        string fallbackMessage,
+        Action<global::Android.Views.View>? clickHandler,
+        global::Android.Views.View? view)
+    {
+        Handler.Options.DebugAction($"Snackbar {errorType}: {ex}");
+        ShowShortToast(fallbackMessage);
+
+        // Only auto-trigger for theme-related exceptions where user interaction was expected
+        if (clickHandler is not null && view is not null)
+        {
+            try
+            {
+                clickHandler(view);
+            }
+            catch (Exception actionEx)
+            {
+                Handler.Options.DebugAction($"Error executing snackbar action: {actionEx}");
+            }
+        }
+    }
+
+    private static bool IsThemeRelated(Exception ex) =>
+        ex is global::Android.Views.InflateException ||
+        (ex is Java.Lang.UnsupportedOperationException &&
+         ex.Message?.Contains("Failed to resolve attribute", StringComparison.Ordinal) == true);
 }

--- a/src/libs/Maui.Android.InAppUpdates/Platforms/Android/DefaultUserInterface.cs
+++ b/src/libs/Maui.Android.InAppUpdates/Platforms/Android/DefaultUserInterface.cs
@@ -37,7 +37,7 @@ public static class DefaultUserInterface
     /// </summary>
     /// <param name="text">The text to display on the snackbar.</param>
     /// <param name="actionText">The text for the action button.</param>
-    /// <param name="clickHandler">The handler for the action button. Can be null if no action is needed.</param>
+    /// <param name="clickHandler">The handler for the action button.</param>
     public static void ShowSnackbar(
         string text,
         string actionText,


### PR DESCRIPTION
**Refactor DefaultUserInterface.cs for Better Error Handling and Code Quality & Prevent Theme-related crashes*

The PR essentially says: "I prefer to show a Snackbar, but if your app's theme prevents it, I will gracefully fall back to a Toast and ensure the intended action still takes place, thus maximizing compatibility.